### PR TITLE
BUG: Change references to file pablo_bert_with_prediction_head

### DIFF
--- a/scripts/DNABERT/Linear_probing.py
+++ b/scripts/DNABERT/Linear_probing.py
@@ -10,7 +10,7 @@ from sklearn.model_selection import StratifiedShuffleSplit
 
 from model import load_model
 from bert_extract_dna_feature import extract_clean_barcode_list, extract_clean_barcode_list_for_aligned
-from pablo_bert_with_prediction_head import train_and_eval
+from bert_with_prediction_head import train_and_eval
 from torch.utils.data import DataLoader, Dataset
 import pandas as pd
 import pickle

--- a/scripts/DNABERT/Plot_Representations.py
+++ b/scripts/DNABERT/Plot_Representations.py
@@ -10,7 +10,7 @@ from sklearn.model_selection import StratifiedShuffleSplit
 
 from model import load_model
 from bert_extract_dna_feature import extract_clean_barcode_list, extract_clean_barcode_list_for_aligned
-from pablo_bert_with_prediction_head import train_and_eval
+from bert_with_prediction_head import train_and_eval
 from torch.utils.data import DataLoader, Dataset
 import pandas as pd
 import pickle

--- a/scripts/DNABERT/genus_kNN.py
+++ b/scripts/DNABERT/genus_kNN.py
@@ -10,7 +10,7 @@ from sklearn.model_selection import StratifiedShuffleSplit
 
 from model import load_model
 from bert_extract_dna_feature import extract_clean_barcode_list, extract_clean_barcode_list_for_aligned
-from pablo_bert_with_prediction_head import train_and_eval
+from bert_with_prediction_head import train_and_eval
 from torch.utils.data import DataLoader, Dataset
 import pandas as pd
 import pickle

--- a/scripts/DNABERT/model.py
+++ b/scripts/DNABERT/model.py
@@ -6,7 +6,7 @@ from torchtext.vocab import build_vocab_from_iterator
 from transformers import AutoModel, AutoTokenizer, BertConfig, BertForMaskedLM
 
 from dnabert.tokenization_dna import DNATokenizer
-from pablo_bert_with_prediction_head import Bert_With_Prediction_Head
+from bert_with_prediction_head import Bert_With_Prediction_Head
 
 device = torch.device("cuda") if torch.cuda.is_available() else "cpu"
 


### PR DESCRIPTION
I've changed all references to the missing file `pablo_bert_with_prediction_head` to use `bert_with_prediction_head` instead. But it was not clear to me if it was okay to change this over or if the missing file would have a different version of the functions being imported.