### PR TITLE
MNT: Fix issues flagged by pre-commit

### DIFF
--- a/barcodebert/bzsl/feature_extraction/__init__.py
+++ b/barcodebert/bzsl/feature_extraction/__init__.py
@@ -1,3 +1,7 @@
-from .utils import extract_clean_barcode_list, extract_clean_barcode_list_for_aligned, extract_dna_features
+from .utils import (
+    extract_clean_barcode_list,
+    extract_clean_barcode_list_for_aligned,
+    extract_dna_features,
+)
 
 __all__ = ["extract_clean_barcode_list", "extract_clean_barcode_list_for_aligned", "extract_dna_features"]

--- a/barcodebert/bzsl/genus_species/main.py
+++ b/barcodebert/bzsl/genus_species/main.py
@@ -6,7 +6,11 @@ from typing import Optional
 import numpy as np
 import torch
 
-from barcodebert.bzsl.genus_species.bayesian_classifier import BayesianClassifier, apply_pca, calculate_priors
+from barcodebert.bzsl.genus_species.bayesian_classifier import (
+    BayesianClassifier,
+    apply_pca,
+    calculate_priors,
+)
 from barcodebert.bzsl.genus_species.dataset import get_data_splits, load_data
 
 

--- a/barcodebert/bzsl/models/dnabert/tokenization_utils.py
+++ b/barcodebert/bzsl/models/dnabert/tokenization_utils.py
@@ -26,7 +26,13 @@ from contextlib import contextmanager
 
 from tokenizers.implementations import BaseTokenizer
 
-from .file_utils import cached_path, hf_bucket_url, is_remote_url, is_tf_available, is_torch_available
+from .file_utils import (
+    cached_path,
+    hf_bucket_url,
+    is_remote_url,
+    is_tf_available,
+    is_torch_available,
+)
 
 if is_tf_available():
     import tensorflow as tf

--- a/barcodebert/bzsl/surrogate_species/bayesian_model.py
+++ b/barcodebert/bzsl/surrogate_species/bayesian_model.py
@@ -6,7 +6,11 @@ from scipy.linalg import solve_triangular
 from scipy.spatial.distance import cdist
 from scipy.special import gammaln
 
-from barcodebert.bzsl.surrogate_species.utils import DataLoader, apply_pca, perf_calc_acc
+from barcodebert.bzsl.surrogate_species.utils import (
+    DataLoader,
+    apply_pca,
+    perf_calc_acc,
+)
 
 
 class Model:

--- a/baselines/cnn/1D_CNN_supervised.py
+++ b/baselines/cnn/1D_CNN_supervised.py
@@ -7,7 +7,6 @@ import torch.nn as nn
 import torch.optim as optim
 from torch.utils.data import DataLoader
 
-
 data_folder = "/h/pmillana/projects/BarcodeBERT_soft_penalty/data"
 train = pd.read_csv(f"{data_folder}/supervised_train.csv")
 test = pd.read_csv(f"{data_folder}/supervised_test.csv")

--- a/baselines/finetuning.py
+++ b/baselines/finetuning.py
@@ -55,7 +55,7 @@ class ClassificationModel(nn.Module):
             out = self.base_model(sequences, attention_mask=mask)[0]
 
         elif self.backbone == "BarcodeBERT":
-            out = self.base_model(sequences, att_mask).hidden_states[-1]
+            out = self.base_model(sequences, mask).hidden_states[-1]
 
         # if backbone != "BarcodeBERT":
         # print(out.shape)

--- a/baselines/finetuning.py
+++ b/baselines/finetuning.py
@@ -3,6 +3,7 @@
 import builtins
 import copy
 import os
+import shutil
 import sys
 import time
 from socket import gethostname

--- a/baselines/io.py
+++ b/baselines/io.py
@@ -2,11 +2,7 @@
 Input/output utilities.
 """
 
-import os
-from inspect import getsourcefile
-
 import torch
-from transformers import BertConfig, BertForMaskedLM, BertForTokenClassification
 
 from baselines.embedders import (
     BarcodeBERTEmbedder,
@@ -16,13 +12,6 @@ from baselines.embedders import (
     HyenaDNAEmbedder,
     NucleotideTransformerEmbedder,
 )
-
-# PACKAGE_DIR = os.path.dirname(os.path.abspath(getsourcefile(lambda: 0)))
-
-
-# def get_project_root() -> str:
-#    return os.path.dirname(PACKAGE_DIR)
-
 
 device = "cuda" if torch.cuda.is_available() else "cpu"
 print("Using device:", device)

--- a/baselines/models/dnabert2.py
+++ b/baselines/models/dnabert2.py
@@ -19,7 +19,13 @@ from transformers.activations import ACT2FN
 from transformers.modeling_outputs import MaskedLMOutput, SequenceClassifierOutput
 from transformers.models.bert.modeling_bert import BertPreTrainedModel
 
-from .dnabert2_padding import index_first_axis, index_put_first_axis, pad_input, unpad_input, unpad_input_only
+from .dnabert2_padding import (
+    index_first_axis,
+    index_put_first_axis,
+    pad_input,
+    unpad_input,
+    unpad_input_only,
+)
 
 try:
     from .flash_attn_triton import flash_attn_qkvpacked_func

--- a/data/data_split.py
+++ b/data/data_split.py
@@ -121,17 +121,17 @@ def split_df(filename):
 
     # Number of repeated species from "test" split in pretrain split
     intersection_records = set(train_species).intersection(set(test_species))
-    print(f"There are { len(intersection_records)} repeated species from test split in train split")
+    print(f"There are {len(intersection_records)} repeated species from test split in train split")
     print()
 
     # Number of repeated species from "unseen" split in "train" split
     intersection_records = set(train_species).intersection(set(unseen_species))
-    print(f"There are { len(intersection_records)} repeated species from unseen split in train split")
+    print(f"There are {len(intersection_records)} repeated species from unseen split in train split")
     print()
 
     # Number of repeated species from "unseen" split in "pretrain" split
     intersection_records = set(pretrain_species).intersection(set(unseen_species))
-    print(f"There are { len(intersection_records)} repeated species from unseen split in pretrain split")
+    print(f"There are {len(intersection_records)} repeated species from unseen split in pretrain split")
     print()
 
     # Get unique genera


### PR DESCRIPTION
@millanp95 Please confirm that the fix for `self.backbone == "BarcodeBERT"` is correct. It was not clear to me whether the undefined `att_mask` [on L57](https://github.com/bioscan-ml/BarcodeBERT/blob/782ab9c6b9a0cf66abd3bb565e607706c18705b7/baselines/finetuning.py#L57) should be fixed by using the `mask` as input to the function [on L65](https://github.com/bioscan-ml/BarcodeBERT/blob/782ab9c6b9a0cf66abd3bb565e607706c18705b7/baselines/finetuning.py#L43), or the reshaped version defined as `att_mask` [on L65](https://github.com/bioscan-ml/BarcodeBERT/blob/782ab9c6b9a0cf66abd3bb565e607706c18705b7/baselines/finetuning.py#L65).

Also, let this be a reminder for you that these kinds of issues are where pre-commit is most helpful - it catches some bugs (e.g. using a variable in a branch before it is defined) when they are introduced. Similarly, pre-commit also caught that `shutil` was being used in the code but wasn't imported anywhere. Hence it is good to pay attention when pre-commit gives an error. If you are ignoring it because it raises errors on other things (e.g. code style) that are like false-positives to you, it would be worth considering disabling the code-style checks so you pay attention proper attention to the true-positives.