### PR TITLE
Added conditional check for `use_cuda` before using `torch.cuda`

### DIFF
--- a/barcodebert/finetuning.py
+++ b/barcodebert/finetuning.py
@@ -472,6 +472,7 @@ def run(config):
             n_epoch=config.epochs,
             total_step=total_step,
             n_samples_seen=n_samples_seen,
+            use_cuda=use_cuda,
         )
         t_end_train = time.time()
 
@@ -659,6 +660,7 @@ def train_one_epoch(
     n_epoch=None,
     total_step=0,
     n_samples_seen=0,
+    use_cuda=True,
 ):
     r"""
     Train the encoder and classifier for one epoch.
@@ -727,8 +729,9 @@ def train_one_epoch(
         # Forward pass --------------------------------------------------------
         t_start_forward = time.time()
         # N.B. To accurately time steps on GPU we need to use torch.cuda.Event
-        ct_forward = torch.cuda.Event(enable_timing=True)
-        ct_forward.record()
+        if use_cuda:
+            ct_forward = torch.cuda.Event(enable_timing=True)
+            ct_forward.record()
         # Perform the forward pass through the model
         out = model(sequences, mask=att_mask, labels=y_true)
         loss = out.loss
@@ -737,14 +740,16 @@ def train_one_epoch(
         # Reset gradients
         optimizer.zero_grad()
         # Now the backward pass
-        ct_backward = torch.cuda.Event(enable_timing=True)
-        ct_backward.record()
+        if use_cuda:
+            ct_backward = torch.cuda.Event(enable_timing=True)
+            ct_backward.record()
         loss.backward()
 
         # Update --------------------------------------------------------------
         # Use our optimizer to update the model parameters
-        ct_optimizer = torch.cuda.Event(enable_timing=True)
-        ct_optimizer.record()
+        if use_cuda:
+            ct_optimizer = torch.cuda.Event(enable_timing=True)
+            ct_optimizer.record()
         optimizer.step()
 
         # Step the scheduler each batch
@@ -758,8 +763,9 @@ def train_one_epoch(
         # Logging -------------------------------------------------------------
         # Log details about training progress
         t_start_logging = time.time()
-        ct_logging = torch.cuda.Event(enable_timing=True)
-        ct_logging.record()
+        if use_cuda:
+            ct_logging = torch.cuda.Event(enable_timing=True)
+            ct_logging.record()
 
         # Update the total loss for the epoch
         loss_batch = loss.clone()
@@ -838,7 +844,8 @@ def train_one_epoch(
                 grp_lr = optimizer.param_groups[lr_idx]["lr"]
                 log_dict[f"Training/stepwise/lr{grp_name}"] = grp_lr
             # Synchronize ensures everything has finished running on each GPU
-            torch.cuda.synchronize()
+            if use_cuda:
+                torch.cuda.synchronize()
             # Record how long it took to do each step in the pipeline
             if t_start_wandb is not None:
                 # Record how long it took to send to wandb last time

--- a/barcodebert/pretraining.py
+++ b/barcodebert/pretraining.py
@@ -92,7 +92,7 @@ def run(config):
     if config.distributed and not use_cuda:
         raise EnvironmentError("Distributed training with NCCL requires CUDA.")
     if not use_cuda:
-        device = torch.device("cpu")
+        raise EnvironmentError("Pretraining requires CUDA.")
     elif config.local_rank is not None:
         device = f"cuda:{config.local_rank}"
     else:


### PR DESCRIPTION
When running any of the scripts on a device without CUDA, `torch.cuda` is lazily loaded but invoking any method in `torch.cuda` will result in an error.

Modified all method calls to `torch.cuda` to have a check for `use_cuda`; otherwise, does not invoke it. Does require `use_cuda` to be passed to training functions in `finetuning.py` and `pretraining.py`.